### PR TITLE
Fix arrow key navigation into Recently Closed card during search

### DIFF
--- a/src/manager/App.tsx
+++ b/src/manager/App.tsx
@@ -360,6 +360,9 @@ export default function App() {
               setFocus({ type: 'tab', cardIndex: 0, tabIndex: 1 });
             } else if (firstWindow && firstWindow.tabs.length === 1) {
               setFocus({ type: 'tab', cardIndex: 0, tabIndex: 0 });
+            } else if (hasRecentlyClosed) {
+              const idx = filteredClosedTabs.length > 1 ? 1 : 0;
+              setFocus({ type: 'recentlyClosedTab', tabIndex: idx });
             }
           } else {
             // Empty → first card
@@ -403,6 +406,8 @@ export default function App() {
           const firstWindow = filteredWindows[0];
           if (firstWindow && firstWindow.tabs.length > 0) {
             setFocus({ type: 'tab', cardIndex: 0, tabIndex: firstWindow.tabs.length - 1 });
+          } else if (hasRecentlyClosed) {
+            setFocus({ type: 'recentlyClosedTab', tabIndex: filteredClosedTabs.length - 1 });
           }
         } else if (focus.type === 'card') {
           // → Search input


### PR DESCRIPTION
## Summary
- When search results show only the Recently Closed card (no open windows match), ArrowDown/ArrowUp from the search input now navigates into the recently closed tabs
- ArrowDown skips to the second item since the first is already highlighted as the search candidate

Fixes #1

## Test plan
- [ ] Search for a term that matches only recently closed tabs (no open tabs match)
- [ ] Press ArrowDown — highlight should move to the 2nd recently closed tab
- [ ] Press ArrowUp — highlight should move to the last recently closed tab
- [ ] Verify existing arrow key behavior for open window cards is unchanged