### PR TITLE
Make window card header click consistent with recently closed card

### DIFF
--- a/src/components/WindowCard.tsx
+++ b/src/components/WindowCard.tsx
@@ -163,11 +163,12 @@ export function WindowCard({
         className={`flex items-center justify-between px-3 py-1.5 cursor-pointer border-b rounded-t-xl ${
           isDark ? 'bg-mist-900 border-white/10' : 'bg-mist-200 border-mist-950/10'
         }`}
-        onClick={() => onFocusWindow(window.id)}
+        onClick={onToggleCollapse}
       >
         <div className="flex items-center gap-2">
           <span
-            className={`text-sm font-medium ${isDark ? 'text-mist-200' : 'text-mist-700'}`}
+            className={`text-sm font-medium ${window.focused ? '' : 'cursor-pointer hover:underline'} ${isDark ? 'text-mist-200' : 'text-mist-700'}`}
+            {...(!window.focused && { onClick: (e: React.MouseEvent) => { e.stopPropagation(); onFocusWindow(window.id); } })}
           >
             Window {displayNumber}
             {window.focused && (


### PR DESCRIPTION
## Summary
- Clicking header whitespace now collapses/expands the window card (matches recently closed card)
- Clicking the window title text (e.g. "Window 2") switches to that Chrome window, with hover underline
- Current window title ("Window 1 (current)") has no click action — clicks fall through to collapse/expand

Closes #5

## Test plan
- [ ] Click header whitespace on a window card — should collapse/expand
- [ ] Click "Window 2" title text — should switch to that window
- [ ] Hover over non-current window title — should show underline
- [ ] Click "Window 1 (current)" title — should collapse/expand (no window switch)
- [ ] Hover over current window title — no underline
- [ ] Header buttons (sort, dedupe, close, collapse) still work as before