### PR TITLE
Polish bulk actions button styling and labels

### DIFF
--- a/src/components/ClosedTabItem.tsx
+++ b/src/components/ClosedTabItem.tsx
@@ -242,7 +242,7 @@ export function ClosedTabItem({
                     onClick={() => handleRestoreToWindow(w.id)}
                     theme={theme}
                   >
-                    Window {getWindowNumber(w.id)} ({w.tabs.length})
+                    Window {getWindowNumber(w.id)} ({w.tabs.length} tabs)
                     {w.focused && <span className={`ml-1 ${isDark ? 'text-white/60' : 'text-mist-950/60'}`}>(current)</span>}
                   </SubmenuItem>
                 ))}

--- a/src/components/RecentlyClosedCard.tsx
+++ b/src/components/RecentlyClosedCard.tsx
@@ -163,7 +163,7 @@ export function RecentlyClosedCard({
 
   return (
     <div
-      className={`rounded-xl outline-none ${
+      className={`rounded-xl outline-none overflow-visible ${
         isDark ? 'bg-white/5' : 'bg-mist-950/[0.025]'
       } ${
         isCardFocused
@@ -202,14 +202,14 @@ export function RecentlyClosedCard({
           {/* Bulk Actions Button - only visible when 2+ tabs selected */}
           {selectedTabCount >= 2 && (
             <div className="relative">
-              <Tooltip text={`Actions for ${selectedTabCount} tabs`} theme={theme} position="bottom-right">
+              <Tooltip text={`Actions for ${selectedTabCount} tabs`} theme={theme} position="top">
                 <button
                   onClick={(e) => { e.stopPropagation(); setShowActionsMenu(!showActionsMenu); }}
                   tabIndex={-1}
                   className={`p-1.5 rounded flex items-center gap-1 ${
                     isDark
-                      ? 'text-blue-400 hover:text-blue-300 hover:bg-mist-700'
-                      : 'text-blue-600 hover:text-blue-700 hover:bg-mist-200'
+                      ? 'text-mist-300 hover:text-mist-200 hover:bg-mist-700'
+                      : 'text-mist-500 hover:text-mist-700 hover:bg-mist-200'
                   }`}
                 >
                   <FileTextOutlined className="text-base" />
@@ -268,7 +268,7 @@ export function RecentlyClosedCard({
                           onClick={() => handleBulkRestoreToWindow(w.id)}
                           theme={theme}
                         >
-                          Window {getWindowNumber(w.id)} ({w.tabs.length})
+                          Window {getWindowNumber(w.id)} ({w.tabs.length} tabs)
                           {w.focused && <span className={`ml-1 ${isDark ? 'text-white/60' : 'text-mist-950/60'}`}>(current)</span>}
                         </SubmenuItem>
                       ))}
@@ -287,7 +287,7 @@ export function RecentlyClosedCard({
                     }`}
                   >
                     <DeleteOutlined className="text-base" />
-                    Hide Selected
+                    Hide {selectedTabCount} Selected
                   </button>
                 </div>
               )}
@@ -297,7 +297,7 @@ export function RecentlyClosedCard({
           {!isSearching && (
             <>
               <div className="relative">
-                <Tooltip text="Restore all" theme={theme} position="bottom-right">
+                <Tooltip text="Restore all" theme={theme} position="top">
                   <button
                     onClick={(e) => { e.stopPropagation(); handleRestoreAllClick(); }}
                     tabIndex={-1}
@@ -344,7 +344,7 @@ export function RecentlyClosedCard({
               </div>
 
               <div className="relative">
-                <Tooltip text="Clear all" theme={theme} position="bottom-right">
+                <Tooltip text="Clear all" theme={theme} position="top">
                   <button
                     onClick={(e) => { e.stopPropagation(); handleClearAllClick(); }}
                     tabIndex={-1}
@@ -391,7 +391,7 @@ export function RecentlyClosedCard({
           )}
 
           {/* Collapse Toggle */}
-          <Tooltip text={isCollapsed ? 'Expand' : 'Collapse'} theme={theme} position="bottom-right">
+          <Tooltip text={isCollapsed ? 'Expand' : 'Collapse'} theme={theme} position="top">
             <button
               onClick={(e) => { e.stopPropagation(); onToggleCollapse(); }}
               tabIndex={-1}

--- a/src/components/TabItem.tsx
+++ b/src/components/TabItem.tsx
@@ -238,7 +238,7 @@ export function TabItem({
                     onClick={() => handleMoveToWindow(w.id)}
                     theme={theme}
                   >
-                    Window {getWindowNumber(w.id)} ({w.tabs.length})
+                    Window {getWindowNumber(w.id)} ({w.tabs.length} tabs)
                   </SubmenuItem>
                 ))}
               </Submenu>

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -4,7 +4,7 @@ interface TooltipProps {
   text: ReactNode;
   children: ReactNode;
   theme: 'light' | 'dark';
-  position?: 'bottom' | 'bottom-right';
+  position?: 'bottom' | 'bottom-right' | 'top';
   flex1?: boolean;
   wrap?: boolean;
 }
@@ -14,6 +14,8 @@ export function Tooltip({ text, children, theme, position = 'bottom', flex1 = fa
 
   const positionClasses = position === 'bottom-right'
     ? 'right-0 top-full mt-1'
+    : position === 'top'
+    ? 'left-1/2 -translate-x-1/2 bottom-full -mb-0.5'
     : 'left-0 top-full mt-1';
 
   return (

--- a/src/components/WindowCard.tsx
+++ b/src/components/WindowCard.tsx
@@ -149,7 +149,7 @@ export function WindowCard({
   return (
     <div
       ref={setNodeRef}
-      className={`rounded-xl outline-none ${
+      className={`rounded-xl outline-none overflow-visible ${
         isDark ? 'bg-white/5' : 'bg-mist-950/[0.025]'
       } ${
         isOver
@@ -193,12 +193,12 @@ export function WindowCard({
           {/* Bulk Actions Button - only visible when 2+ tabs selected */}
           {selectedTabCount >= 2 && (
             <div className="relative">
-              <Tooltip text={`Actions for ${selectedTabCount} tabs`} theme={theme} position="bottom-right">
+              <Tooltip text={`Actions for ${selectedTabCount} tabs`} theme={theme} position="top">
                 <button
                   onClick={(e) => { e.stopPropagation(); setShowActionsMenu(!showActionsMenu); }}
                   tabIndex={-1}
                   className={`p-1.5 rounded flex items-center gap-1 ${
-                    isDark ? 'text-blue-400 hover:text-blue-300 hover:bg-mist-700' : 'text-blue-600 hover:text-blue-700 hover:bg-mist-200'
+                    isDark ? 'text-mist-300 hover:text-mist-200 hover:bg-mist-700' : 'text-mist-500 hover:text-mist-700 hover:bg-mist-200'
                   }`}
                 >
                   <FileTextOutlined className="text-base" />
@@ -232,7 +232,7 @@ export function WindowCard({
                           onClick={() => handleBulkMoveToWindow(w.id)}
                           theme={theme}
                         >
-                          Window {getWindowNumber(w.id)} ({w.tabs.length})
+                          Window {getWindowNumber(w.id)} ({w.tabs.length} tabs)
                         </SubmenuItem>
                       ))}
                     </Submenu>
@@ -248,7 +248,7 @@ export function WindowCard({
                     }`}
                   >
                     <CloseOutlined className="text-base" />
-                    Close All Tabs
+                    Close All {selectedTabCount} tabs
                   </button>
                 </div>
               )}
@@ -258,7 +258,7 @@ export function WindowCard({
           {!isSearching && (
             <>
               <div className="relative">
-                <Tooltip text="Sort tabs" theme={theme} position="bottom-right">
+                <Tooltip text="Sort tabs" theme={theme} position="top">
                   <button
                     onClick={(e) => { e.stopPropagation(); setShowSortMenu(!showSortMenu); }}
                     tabIndex={-1}
@@ -295,7 +295,7 @@ export function WindowCard({
                 )}
               </div>
 
-              <Tooltip text="Remove duplicates" theme={theme} position="bottom-right">
+              <Tooltip text="Remove duplicates" theme={theme} position="top">
                 <button
                   onClick={(e) => { e.stopPropagation(); onDedupe(window.id); }}
                   tabIndex={-1}
@@ -307,7 +307,7 @@ export function WindowCard({
                 </button>
               </Tooltip>
 
-              <Tooltip text="Close window" theme={theme} position="bottom-right">
+              <Tooltip text="Close window" theme={theme} position="top">
                 <button
                   onClick={(e) => { e.stopPropagation(); onCloseWindow(window.id); }}
                   tabIndex={-1}
@@ -322,7 +322,7 @@ export function WindowCard({
           )}
 
           {/* Collapse Toggle */}
-          <Tooltip text={isCollapsed ? 'Expand' : 'Collapse'} theme={theme} position="bottom-right">
+          <Tooltip text={isCollapsed ? 'Expand' : 'Collapse'} theme={theme} position="top">
             <button
               onClick={(e) => { e.stopPropagation(); onToggleCollapse(); }}
               tabIndex={-1}


### PR DESCRIPTION
## Summary
- Changed bulk actions button from blue to mist color scheme
- Moved all card header tooltips above the buttons (with slight overlap to avoid overflow clipping)
- Added new "top" position to Tooltip component
- "Close All Tabs" now shows count: "Close All 3 tabs"
- "Hide Selected" now shows count: "Hide 3 Selected"
- Added "tabs" to window labels in Move/Restore submenus

Closes #7

## Test plan
- [ ] Bulk actions button matches other header button colors
- [ ] Tooltips appear above buttons without being clipped
- [ ] "Close All x tabs" shows correct count
- [ ] Submenu items show "Window 2 (7 tabs)" format