### PR TITLE
Soften dark mode text and custom checkbox styling

### DIFF
--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -1,0 +1,50 @@
+interface CheckboxProps {
+  checked: boolean;
+  indeterminate?: boolean;
+  onChange: () => void;
+  className?: string;
+  theme: 'light' | 'dark';
+}
+
+export function Checkbox({ checked, indeterminate = false, onChange, className = '', theme }: CheckboxProps) {
+  const isDark = theme === 'dark';
+  const isActive = checked || indeterminate;
+
+  return (
+    <div
+      className={`flex-shrink-0 cursor-pointer ${className}`}
+      onMouseDown={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        onChange();
+      }}
+      onClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+      }}
+    >
+      <div
+        className={`w-4 h-4 rounded flex items-center justify-center border transition-colors ${
+          isActive
+            ? isDark
+              ? 'bg-mist-500 border-mist-500'
+              : 'bg-mist-600 border-mist-600'
+            : isDark
+              ? 'bg-mist-800 border-mist-600'
+              : 'bg-white border-mist-300'
+        }`}
+      >
+        {checked && (
+          <svg viewBox="0 0 12 12" className="w-3 h-3 text-white" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M2 6l3 3 5-5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        )}
+        {indeterminate && !checked && (
+          <svg viewBox="0 0 12 12" className="w-3 h-3 text-white" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M2 6h8" strokeLinecap="round" />
+          </svg>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ClosedTabItem.tsx
+++ b/src/components/ClosedTabItem.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { Checkbox } from './Checkbox';
 import {
   MoreOutlined,
   PlusOutlined,
@@ -133,23 +134,13 @@ export function ClosedTabItem({
       onClick={handleClick}
     >
       {/* Checkbox for multi-select */}
-      <input
-        type="checkbox"
-        checked={isChecked}
-        onChange={(e) => {
-          e.stopPropagation();
-          onToggleCheck?.(tab.sessionId, e.target.checked);
-        }}
-        onClick={(e) => e.stopPropagation()}
-        tabIndex={-1}
-        className={`w-4 h-4 rounded flex-shrink-0 cursor-pointer ${
-          isChecked ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
-        } transition-opacity ${
-          isDark
-            ? 'border-mist-600 bg-mist-700 accent-mist-400'
-            : 'border-mist-300 bg-mist-50 accent-mist-600'
-        }`}
-      />
+      <div className={`${isChecked ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'} transition-opacity`}>
+        <Checkbox
+          checked={isChecked}
+          onChange={() => onToggleCheck?.(tab.sessionId, !isChecked)}
+          theme={theme}
+        />
+      </div>
 
       <Tooltip text={getDomain()} theme={theme}>
         <img
@@ -164,7 +155,7 @@ export function ClosedTabItem({
       </Tooltip>
 
       <Tooltip text={<>{tab.title || 'Untitled'}<br /><span className="text-mist-400">{tab.url}</span></>} theme={theme} flex1 wrap>
-        <span className={`text-sm truncate block ${isDark ? 'text-mist-200' : 'text-mist-700'}`}>
+        <span className={`text-sm truncate block ${isDark ? 'text-mist-400' : 'text-mist-700'}`}>
           {tab.title || 'Untitled'}
         </span>
       </Tooltip>

--- a/src/components/RecentlyClosedCard.tsx
+++ b/src/components/RecentlyClosedCard.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState } from 'react';
+import { Checkbox } from './Checkbox';
 import {
   HistoryOutlined,
   ReloadOutlined,
@@ -139,15 +140,8 @@ export function RecentlyClosedCard({
   const isDark = theme === 'dark';
   const selectedTabCount = selectedTabs.size;
 
-  const selectAllRef = useRef<HTMLInputElement>(null);
   const allSelected = selectedTabCount === closedTabs.length && closedTabs.length > 0;
   const someSelected = selectedTabCount > 0 && !allSelected;
-
-  useEffect(() => {
-    if (selectAllRef.current) {
-      selectAllRef.current.indeterminate = someSelected;
-    }
-  }, [someSelected]);
 
   const handleSelectAll = () => {
     if (allSelected) {
@@ -181,19 +175,19 @@ export function RecentlyClosedCard({
           <HistoryOutlined
             className={`text-base ${isDark ? 'text-mist-400' : 'text-mist-500'}`}
           />
-          <span className={`text-sm font-medium ${isDark ? 'text-mist-200' : 'text-mist-700'}`}>
+          <span className={`text-sm font-medium ${isDark ? 'text-mist-300' : 'text-mist-700'}`}>
             Recently Closed
           </span>
           <span
             className={`text-xs flex items-center gap-1 cursor-pointer ${isDark ? 'text-mist-400' : 'text-mist-500'}`}
             onMouseDown={(e) => { e.stopPropagation(); handleSelectAll(); }}
           >
-            (<input
-              ref={selectAllRef}
-              type="checkbox"
+            (<Checkbox
               checked={allSelected}
-              onChange={() => {}}
-              className={`w-4 h-4 rounded cursor-pointer translate-y-px ${isDark ? 'accent-mist-400' : 'accent-mist-600'}`}
+              indeterminate={someSelected}
+              onChange={handleSelectAll}
+              className="translate-y-px"
+              theme={theme}
             />{closedTabs.length} tabs)
           </span>
         </div>

--- a/src/components/TabItem.tsx
+++ b/src/components/TabItem.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { Checkbox } from './Checkbox';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import {
@@ -142,23 +143,13 @@ export function TabItem({
       onClick={handleClick}
     >
       {/* Checkbox for multi-select */}
-      <input
-        type="checkbox"
-        checked={isChecked}
-        onChange={(e) => {
-          e.stopPropagation();
-          onToggleCheck?.(tab.id, e.target.checked);
-        }}
-        onClick={(e) => e.stopPropagation()}
-        tabIndex={-1}
-        className={`w-4 h-4 -mr-1 rounded flex-shrink-0 cursor-pointer ${
-          isChecked ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
-        } transition-opacity ${
-          isDark
-            ? 'border-mist-600 bg-mist-700 accent-mist-400'
-            : 'border-mist-300 bg-mist-50 accent-mist-600'
-        }`}
-      />
+      <div className={`-mr-1 ${isChecked ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'} transition-opacity`}>
+        <Checkbox
+          checked={isChecked}
+          onChange={() => onToggleCheck?.(tab.id, !isChecked)}
+          theme={theme}
+        />
+      </div>
 
       <div
         {...attributes}
@@ -190,7 +181,7 @@ export function TabItem({
       </Tooltip>
 
       <Tooltip text={<>{tab.title || 'Untitled'}<br /><span className="text-mist-400">{tab.url}</span></>} theme={theme} flex1 wrap>
-        <span className={`text-sm truncate block ${isDark ? 'text-mist-200' : 'text-mist-700'}`}>
+        <span className={`text-sm truncate block ${isDark ? 'text-mist-400' : 'text-mist-700'}`}>
           {tab.title || 'Untitled'}
         </span>
       </Tooltip>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, forwardRef, useImperativeHandle } from 'react';
+import { Checkbox } from './Checkbox';
 import {
   SearchOutlined,
   CloseOutlined,
@@ -251,21 +252,17 @@ export const Toolbar = forwardRef<ToolbarHandle, ToolbarProps>(function Toolbar(
 
               <div className="max-h-64 overflow-y-auto py-1">
                 {windows.map(win => (
-                  <label
+                  <div
                     key={win.id}
                     className={`flex items-center gap-3 px-3 py-2 cursor-pointer ${
                       isDark ? 'hover:bg-mist-700' : 'hover:bg-mist-100'
                     }`}
+                    onClick={() => handleToggleWindowSelection(win.id)}
                   >
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       checked={selectedForMerge.has(win.id)}
                       onChange={() => handleToggleWindowSelection(win.id)}
-                      className={`w-4 h-4 rounded ${
-                        isDark
-                          ? 'border-mist-600 bg-mist-700 accent-mist-400'
-                          : 'border-mist-300 bg-mist-50 accent-mist-600'
-                      }`}
+                      theme={theme}
                     />
                     <span className={`text-sm flex-1 truncate ${isDark ? 'text-mist-200' : 'text-mist-700'}`}>
                       Window {getWindowNumber(win.id)}
@@ -276,7 +273,7 @@ export const Toolbar = forwardRef<ToolbarHandle, ToolbarProps>(function Toolbar(
                     <span className={`text-xs ${isDark ? 'text-mist-400' : 'text-mist-500'}`}>
                       {win.tabs.length} tabs
                     </span>
-                  </label>
+                  </div>
                 ))}
               </div>
 

--- a/src/components/WindowCard.tsx
+++ b/src/components/WindowCard.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState } from 'react';
+import { Checkbox } from './Checkbox';
 import {
   SortableContext,
   verticalListSortingStrategy,
@@ -128,15 +129,8 @@ export function WindowCard({
   const otherWindows = allWindows.filter(w => w.id !== window.id);
   const selectedTabCount = selectedTabs.size;
 
-  const selectAllRef = useRef<HTMLInputElement>(null);
   const allSelected = selectedTabCount === window.tabs.length && window.tabs.length > 0;
   const someSelected = selectedTabCount > 0 && !allSelected;
-
-  useEffect(() => {
-    if (selectAllRef.current) {
-      selectAllRef.current.indeterminate = someSelected;
-    }
-  }, [someSelected]);
 
   const handleSelectAll = () => {
     if (allSelected) {
@@ -167,7 +161,7 @@ export function WindowCard({
       >
         <div className="flex items-center gap-2">
           <span
-            className={`text-sm font-medium ${window.focused ? '' : 'cursor-pointer hover:underline'} ${isDark ? 'text-mist-200' : 'text-mist-700'}`}
+            className={`text-sm font-medium ${window.focused ? '' : 'cursor-pointer hover:underline'} ${isDark ? 'text-mist-300' : 'text-mist-700'}`}
             {...(!window.focused && { onMouseDown: (e: React.MouseEvent) => { e.stopPropagation(); onFocusWindow(window.id); } })}
           >
             Window {displayNumber}
@@ -179,12 +173,12 @@ export function WindowCard({
             className={`text-xs flex items-center gap-1 cursor-pointer ${isDark ? 'text-mist-400' : 'text-mist-500'}`}
             onMouseDown={(e) => { e.stopPropagation(); handleSelectAll(); }}
           >
-            (<input
-              ref={selectAllRef}
-              type="checkbox"
+            (<Checkbox
               checked={allSelected}
-              onChange={() => {}}
-              className={`w-4 h-4 rounded cursor-pointer translate-y-px ${isDark ? 'accent-mist-400' : 'accent-mist-600'}`}
+              indeterminate={someSelected}
+              onChange={handleSelectAll}
+              className="translate-y-px"
+              theme={theme}
             />{window.tabs.length} tabs)
           </span>
         </div>


### PR DESCRIPTION
## Summary
- Tab name text softened from `mist-200` to `mist-400` in dark mode
- Card title text softened from `mist-200` to `mist-300` in dark mode
- New `Checkbox` component replaces native `<input type="checkbox">` across all components
- Unchecked checkboxes now have dark background in dark mode (matching Ant Design convention)
- Checked state uses mist color scheme (not blue)

Closes #10

## Test plan
- [ ] Dark mode tab text is softer, not glaring white
- [ ] Card titles are slightly brighter than tab text (visual hierarchy)
- [ ] Checkboxes: unchecked in dark mode shows dark background with subtle border
- [ ] Checkboxes: checked state shows mist-colored fill with white checkmark
- [ ] Clicking tab checkbox toggles check — does NOT switch to that tab
- [ ] Clicking closed tab checkbox toggles check — does NOT restore the tab
- [ ] Select all checkbox in card header works (check, uncheck, indeterminate)
- [ ] Toolbar merge popover checkboxes work (clicking row or checkbox toggles)
- [ ] Drag and drop tabs still works