### PR TITLE
Fix submenu dismissing when mouse crosses gap

### DIFF
--- a/src/components/Submenu.tsx
+++ b/src/components/Submenu.tsx
@@ -51,11 +51,15 @@ export function Submenu({ label, icon, children, theme }: SubmenuProps) {
 
       {showSubmenu && (
         <div
-          className={`absolute top-0 py-1 min-w-40 rounded-xl shadow-lg z-30 ring-1 ${
-            openLeft ? 'right-full mr-1' : 'left-full ml-1'
-          } ${isDark ? 'bg-mist-900 ring-white/10' : 'bg-mist-50 ring-mist-950/10'}`}
+          className={`absolute top-0 ${openLeft ? 'right-full pr-1' : 'left-full pl-1'}`}
         >
-          {children}
+          <div
+            className={`py-1 min-w-40 rounded-xl shadow-lg z-30 ring-1 ${
+              isDark ? 'bg-mist-900 ring-white/10' : 'bg-mist-50 ring-mist-950/10'
+            }`}
+          >
+            {children}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Replaced margin gap (`ml-1`/`mr-1`) between menu and submenu with transparent padding on a wrapper div
- Mouse now stays within the hover zone when moving between menu and submenu

Fixes #15

## Test plan
- [ ] Hover a menu item with submenu, slowly move mouse to submenu — should stay open
- [ ] Submenu still appears on correct side (left/right based on available space)
- [ ] Submenu still has visual gap between it and the parent menu