### PR TITLE
Add 'Reload' option to tab menu

### DIFF
--- a/src/components/TabItem.tsx
+++ b/src/components/TabItem.tsx
@@ -11,6 +11,7 @@ import {
   SelectOutlined,
   CloseOutlined,
   GroupOutlined,
+  ReloadOutlined,
 } from '@ant-design/icons';
 import { Button, Tooltip, Dropdown } from 'antd';
 import type { MenuProps } from 'antd';
@@ -224,6 +225,8 @@ export function TabItem({
                 onClick: ({ domEvent }) => { domEvent.stopPropagation(); chrome.tabs.ungroup(tab.id); } });
             }
             items.push(
+              { key: 'reload', icon: <ReloadOutlined />, label: 'Reload',
+                onClick: ({ domEvent }) => { domEvent.stopPropagation(); chrome.tabs.reload(tab.id); } },
               { key: 'pin', icon: <PushpinOutlined />, label: tab.pinned ? 'Unpin' : 'Pin',
                 onClick: ({ domEvent }) => { domEvent.stopPropagation(); onTogglePin(tab.id, !tab.pinned); } },
               { type: 'divider' },


### PR DESCRIPTION
Closes #25

Adds a **Reload** item to each tab's '⋮' more-options menu in the WindowCard, placed between the move actions and Pin. It calls `chrome.tabs.reload(tabId)` directly, following the same pattern as the existing 'Remove from Group' item.

## Testing
Verified end-to-end with Playwright driving Chromium with the built extension loaded unpacked from `dist/`:
- Opened a test page and planted a JS marker on it (`window.__reloadMarker = 42`)
- Opened the Tab Cluster manager page, hovered the test page's tab row, opened its '⋮' menu — the **Reload** item renders with the reload icon
- Clicked **Reload** — the tab's `load` event fired and the marker was gone afterward, confirming a real reload