### PR TITLE
Extend Recently Closed beyond the 25-session API limit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,11 +112,15 @@ Key design decisions and their motivations:
 - Rationale: Consistent icon style, easier to maintain and swap icons
 
 ### Recently Closed Tabs
-- Limited to 30 tabs maximum (Chrome sessions API returns up to 25 sessions, but closed windows can contain many tabs)
-- Chrome sessions API doesn't support deletion, so "Hide" stores session IDs in localStorage
-- Hidden IDs are capped at 1000 entries to prevent unbounded growth
-- Auto-cleanup removes stale IDs when sessions expire or are restored
-- Rationale: Provides expected "delete" UX despite API limitation
+- Hybrid data source: Chrome sessions API (up to 25 sessions) merged with an own closed-tab log
+- The background service worker records every tab close to `chrome.storage.local` (cap 1000, FIFO); a tabId→metadata cache in `chrome.storage.session` provides url/title at close time (tabs.onRemoved doesn't include them)
+- Merge dedupes log entries against session entries (same URL, closed within 5s); session entries win because `chrome.sessions.restore()` recovers full back/forward history, while log entries reopen via `chrome.tabs.create({url})`
+- Sessions API is kept because it covers browser-quit/crash closes, which tabs.onRemoved misses
+- 30 tabs shown by default; "Show more" reveals +30 at a time; search filters the full merged list before the display cap
+- Log entries support real deletion; for session entries the sessions API doesn't support deletion, so "Hide" stores session IDs in localStorage (capped at 1000)
+- Noise is never logged: chrome://, chrome-extension://, about:*, incognito tabs
+- Merge/dedupe logic is pure functions in `src/services/closedTabLog.ts` (unit-tested); constants are duplicated in `public/background.js` because it ships un-bundled
+- Rationale: Extends history beyond the ~25-session API limit while keeping full-fidelity restore where available
 
 ### Card Ordering
 - Current (focused) window is always sorted first, appearing at top of first column

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A Chrome browser extension for managing tabs and windows, similar to TabCluster.
 │   │   └── DuplicatesModal.tsx
 │   ├── hooks/
 │   │   ├── useWindows.ts  # Chrome windows API wrapper
-│   │   ├── useRecentlyClosed.ts # Chrome sessions API wrapper
+│   │   ├── useRecentlyClosed.ts # Sessions API merged with own closed-tab log
 │   │   ├── useSearch.ts   # Search/filter logic
 │   │   ├── useTheme.ts    # Theme toggle with persistence
 │   │   ├── useMasonry.ts  # Shortest-column-first layout algorithm
@@ -179,3 +179,4 @@ To customize the shortcut:
 The extension requires:
 - `tabs` - Access to tab information (title, URL, favicon)
 - `sessions` - Access to recently closed tabs
+- `storage` - Persist the closed-tab log locally (extends history beyond the sessions API's ~25-session limit)

--- a/public/background.js
+++ b/public/background.js
@@ -39,3 +39,117 @@ function openTabCluster() {
     });
   });
 }
+
+// ---- Closed-tab log ----
+// Records every tab close into chrome.storage.local so the manager can show
+// recently closed tabs beyond the sessions API's ~25-session limit.
+// tabs.onRemoved doesn't include url/title, so a tabId -> metadata cache is
+// kept in chrome.storage.session (survives service worker restarts).
+
+// KEEP IN SYNC with src/services/closedTabLog.ts (this file is not bundled and cannot import it)
+const CLOSED_TAB_LOG_KEY = 'closedTabLog';
+const CLOSED_TAB_LOG_CAP = 1000;
+const NOISE_URL_PREFIXES = ['chrome://', 'chrome-extension://', 'edge://', 'devtools://', 'about:'];
+
+const TAB_META_CACHE_KEY = 'tabMetaCache';
+
+function isNoiseUrl(url) {
+  if (!url) return true;
+  return NOISE_URL_PREFIXES.some((prefix) => url.startsWith(prefix));
+}
+
+// All cache/log mutations run through this chain so a burst of onRemoved events
+// (e.g. closing a whole window) can't lose updates to read-modify-write races.
+let opQueue = Promise.resolve();
+function enqueue(op) {
+  opQueue = opQueue.then(op).catch((err) => console.error('[closedTabLog]', err));
+}
+
+async function getTabMetaCache() {
+  const result = await chrome.storage.session.get(TAB_META_CACHE_KEY);
+  return result[TAB_META_CACHE_KEY] ?? {};
+}
+
+function setTabMetaCache(cache) {
+  return chrome.storage.session.set({ [TAB_META_CACHE_KEY]: cache });
+}
+
+function tabMeta(tab) {
+  return {
+    url: tab.url || tab.pendingUrl || '',
+    title: tab.title || '',
+    favIconUrl: tab.favIconUrl,
+  };
+}
+
+async function upsertTabMeta(tab) {
+  if (!tab || tab.id === undefined || tab.incognito) return;
+  const cache = await getTabMetaCache();
+  cache[tab.id] = tabMeta(tab);
+  await setTabMetaCache(cache);
+}
+
+async function seedTabMetaCache() {
+  const tabs = await chrome.tabs.query({});
+  const cache = await getTabMetaCache();
+  for (const tab of tabs) {
+    if (tab.id !== undefined && !tab.incognito) {
+      cache[tab.id] = tabMeta(tab);
+    }
+  }
+  await setTabMetaCache(cache);
+}
+
+async function logRemovedTab(tabId) {
+  const cache = await getTabMetaCache();
+  const meta = cache[tabId];
+  if (meta) {
+    delete cache[tabId];
+    await setTabMetaCache(cache);
+  }
+  if (!meta || isNoiseUrl(meta.url)) return;
+
+  const entry = {
+    id: `log-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    url: meta.url,
+    title: meta.title,
+    closedTime: Date.now(),
+  };
+  if (meta.favIconUrl && /^https?:\/\//.test(meta.favIconUrl)) {
+    entry.favIconUrl = meta.favIconUrl;
+  }
+  const result = await chrome.storage.local.get(CLOSED_TAB_LOG_KEY);
+  const log = result[CLOSED_TAB_LOG_KEY] ?? [];
+  await chrome.storage.local.set({
+    [CLOSED_TAB_LOG_KEY]: [entry, ...log].slice(0, CLOSED_TAB_LOG_CAP),
+  });
+}
+
+chrome.tabs.onCreated.addListener((tab) => {
+  enqueue(() => upsertTabMeta(tab));
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.url || changeInfo.title || changeInfo.favIconUrl) {
+    enqueue(() => upsertTabMeta(tab));
+  }
+});
+
+chrome.tabs.onReplaced.addListener((addedTabId, removedTabId) => {
+  enqueue(async () => {
+    const cache = await getTabMetaCache();
+    delete cache[removedTabId];
+    await setTabMetaCache(cache);
+    const tab = await chrome.tabs.get(addedTabId);
+    await upsertTabMeta(tab);
+  });
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  enqueue(() => logRemovedTab(tabId));
+});
+
+// Runs after the synchronous listener registrations above, so on every service
+// worker spin-up the seed is first in the queue — events that woke the worker
+// execute after it and find the cache populated.
+enqueue(seedTabMetaCache);

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,7 +6,8 @@
   "permissions": [
     "tabs",
     "sessions",
-    "tabGroups"
+    "tabGroups",
+    "storage"
   ],
   "action": {
     "default_popup": "popup/index.html",

--- a/src/components/ClosedTabItem.tsx
+++ b/src/components/ClosedTabItem.tsx
@@ -77,9 +77,15 @@ export function ClosedTabItem({
 
   const isDark = theme === 'dark';
 
+  // Log-backed entries reopen as a fresh tab — their original location is unknown,
+  // and removing them is a real deletion (session entries are only hidden)
+  const isLogEntry = tab.source === 'log';
+
   const menuItems: MenuProps['items'] = [
-    { key: 'restore', icon: <HistoryOutlined />, label: 'Restore to Original Location',
-      onClick: ({ domEvent }) => { domEvent.stopPropagation(); onRestore(tab.sessionId); } },
+    ...(!isLogEntry ? [{
+      key: 'restore', icon: <HistoryOutlined />, label: 'Restore to Original Location',
+      onClick: ({ domEvent }: { domEvent: React.MouseEvent | React.KeyboardEvent }) => { domEvent.stopPropagation(); onRestore(tab.sessionId); },
+    }] : []),
     { key: 'new-window', icon: <PlusOutlined />, label: 'Restore in New Window',
       onClick: ({ domEvent }) => { domEvent.stopPropagation(); onRestoreInNewWindow(tab.sessionId); } },
     { key: 'current-window', icon: <ImportOutlined />, label: 'Restore in Current Window',
@@ -96,7 +102,7 @@ export function ClosedTabItem({
       })) as MenuProps['items'],
     }] : []),
     { type: 'divider' },
-    { key: 'hide', icon: <DeleteOutlined />, label: 'Hide', danger: true,
+    { key: 'hide', icon: <DeleteOutlined />, label: isLogEntry ? 'Delete' : 'Hide', danger: true,
       onClick: ({ domEvent }) => { domEvent.stopPropagation(); onDelete(tab.sessionId); } },
   ];
 

--- a/src/components/RecentlyClosedCard.tsx
+++ b/src/components/RecentlyClosedCard.tsx
@@ -39,6 +39,8 @@ interface RecentlyClosedCardProps {
   onBulkRestoreToWindow: (sessionIds: string[], windowId: number) => void;
   onRestoreAll: () => void;
   onClearAll: () => void;
+  moreCount: number;
+  onShowMore: () => void;
   theme: 'light' | 'dark';
 }
 
@@ -63,6 +65,8 @@ export function RecentlyClosedCard({
   onBulkRestoreToWindow,
   onRestoreAll,
   onClearAll,
+  moreCount,
+  onShowMore,
   theme,
 }: RecentlyClosedCardProps) {
   const [selectedTabs, setSelectedTabs] = useState<Set<string>>(new Set());
@@ -216,7 +220,7 @@ export function RecentlyClosedCard({
                 }
                 items.push(
                   { type: 'divider' },
-                  { key: 'hide', icon: <DeleteOutlined />, label: `Hide ${selectedTabCount} Selected`, danger: true,
+                  { key: 'hide', icon: <DeleteOutlined />, label: `Remove ${selectedTabCount} Selected`, danger: true,
                     onClick: ({ domEvent }) => { domEvent.stopPropagation(); handleBulkDelete(); } },
                 );
                 return items;
@@ -341,6 +345,18 @@ export function RecentlyClosedCard({
             theme={theme}
           />
           ))}
+          {moreCount > 0 && (
+            <Button
+              type="text"
+              block
+              size="small"
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={onShowMore}
+              className={isDark ? '!text-mist-400' : '!text-mist-500'}
+            >
+              Show {Math.min(30, moreCount)} more ({moreCount} hidden)
+            </Button>
+          )}
         </div>
       )}
     </div>

--- a/src/hooks/useRecentlyClosed.ts
+++ b/src/hooks/useRecentlyClosed.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { ClosedTabInfo } from '../types';
 import { getRecentlyClosed, subscribeToSessionChanges } from '../services/chromeApi';
+import { getClosedTabLog, mergeClosedTabs, subscribeToLogChanges } from '../services/closedTabLog';
 
 export function useRecentlyClosed(hiddenIds: Set<string>) {
   const [closedTabs, setClosedTabs] = useState<ClosedTabInfo[]>([]);
@@ -13,9 +14,12 @@ export function useRecentlyClosed(hiddenIds: Set<string>) {
 
   const refresh = useCallback(async () => {
     try {
+      const [sessionTabs, logEntries] = await Promise.all([
+        getRecentlyClosed(),
+        getClosedTabLog(),
+      ]);
       // Always use the current hiddenIds from the ref
-      const data = await getRecentlyClosed(hiddenIdsRef.current);
-      setClosedTabs(data);
+      setClosedTabs(mergeClosedTabs(sessionTabs, logEntries, hiddenIdsRef.current));
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load recently closed tabs');
@@ -24,11 +28,15 @@ export function useRecentlyClosed(hiddenIds: Set<string>) {
     }
   }, []); // No dependencies - uses ref for latest value
 
-  // Subscribe to session changes once
+  // Subscribe to session and log changes once
   useEffect(() => {
     refresh();
-    const unsubscribe = subscribeToSessionChanges(refresh);
-    return unsubscribe;
+    const unsubscribeSessions = subscribeToSessionChanges(refresh);
+    const unsubscribeLog = subscribeToLogChanges(refresh);
+    return () => {
+      unsubscribeSessions();
+      unsubscribeLog();
+    };
   }, [refresh]);
 
   // Re-fetch when hiddenIds changes

--- a/src/manager/App.tsx
+++ b/src/manager/App.tsx
@@ -34,6 +34,7 @@ import {
   findDuplicates,
   removeDuplicates,
 } from '../services/tabOperations';
+import { isLogId, removeLogEntries, clearClosedTabLog } from '../services/closedTabLog';
 
 type FocusTarget =
   | { type: 'search' }
@@ -45,11 +46,12 @@ type FocusTarget =
 // CardItem for masonry layout - union of window cards and recently closed card
 type CardItem =
   | { type: 'window'; window: WindowInfo; cardIndex: number }
-  | { type: 'recentlyClosed'; closedTabs: ClosedTabInfo[] };
+  | { type: 'recentlyClosed'; closedTabs: ClosedTabInfo[]; moreCount: number };
 
 // Constants for height estimation in masonry layout
 const CARD_HEADER_HEIGHT = 48;
 const TAB_ITEM_HEIGHT = 32;
+const SHOW_MORE_FOOTER_HEIGHT = 36;
 
 // localStorage key for hidden closed tabs
 const HIDDEN_CLOSED_TABS_KEY = 'tabcluster-hidden-closed-tabs';
@@ -155,18 +157,32 @@ export default function App() {
       .filter(window => window.tabs.length > 0);
   }, [windows, tabGroups, searchQuery]);
 
-  // Filter closed tabs by search query, then cap display count
+  // Filter closed tabs by search query (over the full merged list), then cap display count
   const MAX_RECENTLY_CLOSED_TABS_TO_SHOW = 30;
-  const filteredClosedTabs = useMemo(() => {
-    const filtered = searchQuery.trim()
+  const [visibleClosedCount, setVisibleClosedCount] = useState(MAX_RECENTLY_CLOSED_TABS_TO_SHOW);
+  const searchFilteredClosedTabs = useMemo(() => {
+    return searchQuery.trim()
       ? closedTabs.filter(tab => {
           const lowerQuery = searchQuery.toLowerCase();
           return tab.title.toLowerCase().includes(lowerQuery) ||
             tab.url.toLowerCase().includes(lowerQuery);
         })
       : closedTabs;
-    return filtered.slice(0, MAX_RECENTLY_CLOSED_TABS_TO_SHOW);
   }, [closedTabs, searchQuery]);
+  const filteredClosedTabs = useMemo(
+    () => searchFilteredClosedTabs.slice(0, visibleClosedCount),
+    [searchFilteredClosedTabs, visibleClosedCount]
+  );
+  const closedTabsMoreCount = searchFilteredClosedTabs.length - filteredClosedTabs.length;
+
+  // Reset pagination when the search query changes
+  useEffect(() => {
+    setVisibleClosedCount(MAX_RECENTLY_CLOSED_TABS_TO_SHOW);
+  }, [searchQuery]);
+
+  const handleShowMoreClosedTabs = useCallback(() => {
+    setVisibleClosedCount(count => count + MAX_RECENTLY_CLOSED_TABS_TO_SHOW);
+  }, []);
 
   // Masonry layout: distribute cards across columns using "shortest column first" algorithm
   const columnCount = useColumnCount();
@@ -185,6 +201,7 @@ export default function App() {
     const recentlyClosedCard: CardItem = {
       type: 'recentlyClosed' as const,
       closedTabs: filteredClosedTabs,
+      moreCount: closedTabsMoreCount,
     };
 
     // Position Recently Closed card:
@@ -198,13 +215,14 @@ export default function App() {
     const items = [...windowCards];
     items.splice(insertIndex, 0, recentlyClosedCard);
     return items;
-  }, [filteredWindows, filteredClosedTabs, columnCount]);
+  }, [filteredWindows, filteredClosedTabs, closedTabsMoreCount, columnCount]);
 
   const getCardHeight = useCallback((item: CardItem): number => {
     if (item.type === 'window') {
       return CARD_HEADER_HEIGHT + item.window.tabs.length * TAB_ITEM_HEIGHT;
     } else {
-      return CARD_HEADER_HEIGHT + item.closedTabs.length * TAB_ITEM_HEIGHT;
+      return CARD_HEADER_HEIGHT + item.closedTabs.length * TAB_ITEM_HEIGHT +
+        (item.moreCount > 0 ? SHOW_MORE_FOOTER_HEIGHT : 0);
     }
   }, []);
 
@@ -704,11 +722,25 @@ export default function App() {
   // Single Item Handlers - Always switch to the restored tab
   // ---------------------------------------------------------------------------
 
+  // Unified restore for both entry types. Session entries restore via the sessions API
+  // (with full back/forward history); log entries can only reopen as a fresh tab, and
+  // are removed from the log once the tab is successfully created.
+  const restoreEntry = async (id: string): Promise<{ tabId?: number; windowId?: number }> => {
+    const entry = closedTabs.find(tab => tab.sessionId === id);
+    if (entry?.source === 'log') {
+      const tab = await chrome.tabs.create({ url: entry.url, active: false });
+      await removeLogEntries([id]);
+      return { tabId: tab.id, windowId: tab.windowId };
+    }
+    const session = await restoreClosedTab(id);
+    return { tabId: session.tab?.id, windowId: session.tab?.windowId };
+  };
+
   const handleRestoreClosedTab = async (sessionId: string) => {
     try {
-      const session = await restoreClosedTab(sessionId);
-      if (session.tab?.id && session.tab?.windowId) {
-        await switchToTab(session.tab.id, session.tab.windowId);
+      const { tabId, windowId } = await restoreEntry(sessionId);
+      if (tabId && windowId) {
+        await switchToTab(tabId, windowId);
       }
     } catch (err) {
       console.error('Failed to restore closed tab:', err);
@@ -717,9 +749,9 @@ export default function App() {
 
   const handleRestoreClosedTabInNewWindow = async (sessionId: string) => {
     try {
-      const session = await restoreClosedTab(sessionId);
-      if (session.tab?.id) {
-        const newWindow = await chrome.windows.create({ tabId: session.tab.id });
+      const { tabId } = await restoreEntry(sessionId);
+      if (tabId) {
+        const newWindow = await chrome.windows.create({ tabId });
         if (newWindow.id) {
           await chrome.windows.update(newWindow.id, { focused: true });
         }
@@ -732,10 +764,10 @@ export default function App() {
   const handleRestoreClosedTabInCurrentWindow = async (sessionId: string) => {
     try {
       const currentWindow = await chrome.windows.getCurrent();
-      const session = await restoreClosedTab(sessionId);
-      if (session.tab?.id && currentWindow.id) {
-        await chrome.tabs.move(session.tab.id, { windowId: currentWindow.id, index: -1 });
-        await switchToTab(session.tab.id, currentWindow.id);
+      const { tabId } = await restoreEntry(sessionId);
+      if (tabId && currentWindow.id) {
+        await chrome.tabs.move(tabId, { windowId: currentWindow.id, index: -1 });
+        await switchToTab(tabId, currentWindow.id);
       }
     } catch (err) {
       console.error('Failed to restore closed tab:', err);
@@ -744,10 +776,10 @@ export default function App() {
 
   const handleRestoreClosedTabToWindow = async (sessionId: string, windowId: number) => {
     try {
-      const session = await restoreClosedTab(sessionId);
-      if (session.tab?.id) {
-        await chrome.tabs.move(session.tab.id, { windowId, index: -1 });
-        await switchToTab(session.tab.id, windowId);
+      const { tabId } = await restoreEntry(sessionId);
+      if (tabId) {
+        await chrome.tabs.move(tabId, { windowId, index: -1 });
+        await switchToTab(tabId, windowId);
       }
     } catch (err) {
       console.error('Failed to restore closed tab to window:', err);
@@ -755,6 +787,11 @@ export default function App() {
   };
 
   const handleDeleteClosedTab = (sessionId: string) => {
+    if (isLogId(sessionId)) {
+      // Log entries support real deletion; storage.onChanged triggers the refresh
+      removeLogEntries([sessionId]);
+      return;
+    }
     // Chrome's sessions API doesn't support deleting individual items,
     // so we hide them locally by storing in localStorage
     setHiddenClosedTabs(prev => {
@@ -774,7 +811,7 @@ export default function App() {
 
     for (const sessionId of sessionIds) {
       try {
-        await restoreClosedTab(sessionId);
+        await restoreEntry(sessionId);
       } catch (err) {
         console.error('Failed to restore closed tab:', err);
       }
@@ -788,9 +825,9 @@ export default function App() {
 
     for (const sessionId of sessionIds) {
       try {
-        const session = await restoreClosedTab(sessionId);
-        if (session.tab?.id) {
-          restoredTabIds.push(session.tab.id);
+        const { tabId } = await restoreEntry(sessionId);
+        if (tabId) {
+          restoredTabIds.push(tabId);
         }
       } catch (err) {
         console.error('Failed to restore closed tab:', err);
@@ -821,9 +858,9 @@ export default function App() {
 
     for (const sessionId of sessionIds) {
       try {
-        const session = await restoreClosedTab(sessionId);
-        if (session.tab?.id) {
-          await chrome.tabs.move(session.tab.id, { windowId: currentWindow.id, index: -1 });
+        const { tabId } = await restoreEntry(sessionId);
+        if (tabId) {
+          await chrome.tabs.move(tabId, { windowId: currentWindow.id, index: -1 });
         }
       } catch (err) {
         console.error('Failed to restore closed tab:', err);
@@ -838,9 +875,9 @@ export default function App() {
 
     for (const sessionId of sessionIds) {
       try {
-        const session = await restoreClosedTab(sessionId);
-        if (session.tab?.id) {
-          await chrome.tabs.move(session.tab.id, { windowId, index: -1 });
+        const { tabId } = await restoreEntry(sessionId);
+        if (tabId) {
+          await chrome.tabs.move(tabId, { windowId, index: -1 });
         }
       } catch (err) {
         console.error('Failed to restore closed tab to window:', err);
@@ -860,8 +897,16 @@ export default function App() {
   };
 
   const handleClearAllClosedTabs = async () => {
-    // Chrome's sessions API doesn't support clearing history directly.
-    console.warn('Clear history is not directly supported by Chrome sessions API');
+    await clearClosedTabLog();
+    // Chrome's sessions API doesn't support clearing, so hide the session-backed entries
+    setHiddenClosedTabs(prev => {
+      const next = new Set(prev);
+      closedTabs
+        .filter(tab => tab.source === 'session')
+        .forEach(tab => next.add(tab.sessionId));
+      saveHiddenClosedTabs(next);
+      return next;
+    });
   };
 
   const handleDragStart = (event: DragStartEvent) => {
@@ -1031,6 +1076,8 @@ export default function App() {
                         onBulkRestoreToWindow={handleBulkRestoreClosedTabsToWindow}
                         onRestoreAll={handleRestoreAllClosedTabs}
                         onClearAll={handleClearAllClosedTabs}
+                        moreCount={closedTabsMoreCount}
+                        onShowMore={handleShowMoreClosedTabs}
                         theme={theme}
                       />
                     );

--- a/src/services/__tests__/closedTabLog.test.ts
+++ b/src/services/__tests__/closedTabLog.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isLogId,
+  isNoiseUrl,
+  appendToLog,
+  mergeClosedTabs,
+  DEDUPE_WINDOW_MS,
+} from '../closedTabLog';
+import { ClosedTabInfo, ClosedTabLogEntry } from '../../types';
+
+function sessionTab(overrides: Partial<ClosedTabInfo> = {}): ClosedTabInfo {
+  return {
+    sessionId: '5',
+    source: 'session',
+    title: 'Example',
+    url: 'https://example.com/',
+    closedTime: 1_000_000,
+    ...overrides,
+  };
+}
+
+function logEntry(overrides: Partial<ClosedTabLogEntry> = {}): ClosedTabLogEntry {
+  return {
+    id: 'log-1000000-abc123',
+    title: 'Example',
+    url: 'https://example.com/',
+    closedTime: 1_000_000,
+    ...overrides,
+  };
+}
+
+describe('isLogId', () => {
+  it('recognizes synthetic log ids', () => {
+    expect(isLogId('log-1720680000000-x7f3a2')).toBe(true);
+  });
+
+  it('rejects real Chrome sessionIds', () => {
+    expect(isLogId('5')).toBe(false);
+    expect(isLogId('5.12')).toBe(false);
+  });
+});
+
+describe('isNoiseUrl', () => {
+  it('flags browser-internal and empty urls', () => {
+    expect(isNoiseUrl('chrome://newtab/')).toBe(true);
+    expect(isNoiseUrl('chrome-extension://abc/manager/index.html')).toBe(true);
+    expect(isNoiseUrl('about:blank')).toBe(true);
+    expect(isNoiseUrl('devtools://devtools/bundled/inspector.html')).toBe(true);
+    expect(isNoiseUrl('edge://settings')).toBe(true);
+    expect(isNoiseUrl('')).toBe(true);
+  });
+
+  it('allows normal web urls', () => {
+    expect(isNoiseUrl('https://example.com/')).toBe(false);
+    expect(isNoiseUrl('http://localhost:3000/')).toBe(false);
+  });
+});
+
+describe('appendToLog', () => {
+  it('prepends new entries (newest first)', () => {
+    const log = [logEntry({ id: 'log-1-a' })];
+    const result = appendToLog(log, logEntry({ id: 'log-2-b' }));
+    expect(result.map(e => e.id)).toEqual(['log-2-b', 'log-1-a']);
+  });
+
+  it('evicts oldest entries beyond the cap', () => {
+    const log = Array.from({ length: 3 }, (_, i) => logEntry({ id: `log-${i}-x` }));
+    const result = appendToLog(log, logEntry({ id: 'log-new-y' }), 3);
+    expect(result).toHaveLength(3);
+    expect(result[0].id).toBe('log-new-y');
+    expect(result.map(e => e.id)).not.toContain('log-2-x');
+  });
+});
+
+describe('mergeClosedTabs', () => {
+  it('absorbs a log entry duplicating a session entry within the dedupe window', () => {
+    const session = sessionTab({ closedTime: 1_000_000 });
+    const log = logEntry({ closedTime: 1_000_000 + DEDUPE_WINDOW_MS });
+    const result = mergeClosedTabs([session], [log], new Set());
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('session');
+  });
+
+  it('keeps a same-url log entry outside the dedupe window', () => {
+    const session = sessionTab({ closedTime: 1_000_000 });
+    const log = logEntry({ closedTime: 1_000_000 + DEDUPE_WINDOW_MS + 1 });
+    const result = mergeClosedTabs([session], [log], new Set());
+    expect(result).toHaveLength(2);
+  });
+
+  it('consumes session twins one-to-one so duplicate closes both survive', () => {
+    // One session entry, two log entries with the same url/time:
+    // only one log entry should be absorbed
+    const session = sessionTab();
+    const logs = [logEntry({ id: 'log-1-a' }), logEntry({ id: 'log-2-b' })];
+    const result = mergeClosedTabs([session], logs, new Set());
+    expect(result).toHaveLength(2);
+    expect(result.filter(t => t.source === 'log')).toHaveLength(1);
+  });
+
+  it('hides session entries without resurrecting their absorbed log twin', () => {
+    const session = sessionTab({ sessionId: '7' });
+    const log = logEntry();
+    const result = mergeClosedTabs([session], [log], new Set(['7']));
+    expect(result).toHaveLength(0);
+  });
+
+  it('filters hidden log ids', () => {
+    const log = logEntry({ id: 'log-1-a', url: 'https://other.com/' });
+    const result = mergeClosedTabs([], [log], new Set(['log-1-a']));
+    expect(result).toHaveLength(0);
+  });
+
+  it('drops noise urls from the log defensively', () => {
+    const log = logEntry({ url: 'chrome://newtab/' });
+    expect(mergeClosedTabs([], [log], new Set())).toHaveLength(0);
+  });
+
+  it('sorts by closedTime desc with session winning ties', () => {
+    const oldSession = sessionTab({ sessionId: '1', url: 'https://a.com/', closedTime: 100 });
+    const newLog = logEntry({ id: 'log-1-a', url: 'https://b.com/', closedTime: 300 });
+    const tieSession = sessionTab({ sessionId: '2', url: 'https://c.com/', closedTime: 200 });
+    const tieLog = logEntry({ id: 'log-2-b', url: 'https://d.com/', closedTime: 200 });
+    const result = mergeClosedTabs([oldSession, tieSession], [newLog, tieLog], new Set());
+    expect(result.map(t => t.sessionId)).toEqual(['log-1-a', '2', 'log-2-b', '1']);
+  });
+});

--- a/src/services/chromeApi.ts
+++ b/src/services/chromeApi.ts
@@ -131,20 +131,21 @@ export function subscribeToChanges(callback: () => void): () => void {
 
 // Recently closed tabs API functions
 
-export async function getRecentlyClosed(hiddenIds?: Set<string>): Promise<ClosedTabInfo[]> {
+// Hidden-tab filtering happens in mergeClosedTabs (closedTabLog.ts), which needs the
+// unfiltered session list to dedupe log entries against.
+export async function getRecentlyClosed(): Promise<ClosedTabInfo[]> {
   const sessions = await chrome.sessions.getRecentlyClosed({ maxResults: 25 });
   const closedTabs: ClosedTabInfo[] = [];
 
   const isExtensionUrl = (url: string) => url.startsWith('chrome-extension://');
-  const isHidden = (sessionId: string) => hiddenIds?.has(sessionId) ?? false;
 
   for (const session of sessions) {
     if (session.tab) {
-      // Individual closed tab - skip extension pages and hidden tabs
-      const sessionId = session.tab.sessionId!;
-      if (!isExtensionUrl(session.tab.url || '') && !isHidden(sessionId)) {
+      // Individual closed tab - skip extension pages
+      if (!isExtensionUrl(session.tab.url || '')) {
         closedTabs.push({
-          sessionId,
+          sessionId: session.tab.sessionId!,
+          source: 'session',
           title: session.tab.title || '',
           url: session.tab.url || '',
           favIconUrl: session.tab.favIconUrl,
@@ -152,12 +153,12 @@ export async function getRecentlyClosed(hiddenIds?: Set<string>): Promise<Closed
         });
       }
     } else if (session.window) {
-      // Closed window - flatten all tabs, skip extension pages and hidden tabs
+      // Closed window - flatten all tabs, skip extension pages
       for (const tab of session.window.tabs || []) {
-        const sessionId = tab.sessionId!;
-        if (!isExtensionUrl(tab.url || '') && !isHidden(sessionId)) {
+        if (!isExtensionUrl(tab.url || '')) {
           closedTabs.push({
-            sessionId,
+            sessionId: tab.sessionId!,
+            source: 'session',
             title: tab.title || '',
             url: tab.url || '',
             favIconUrl: tab.favIconUrl,

--- a/src/services/closedTabLog.ts
+++ b/src/services/closedTabLog.ts
@@ -1,0 +1,111 @@
+import { ClosedTabInfo, ClosedTabLogEntry } from '../types';
+
+// KEEP IN SYNC with public/background.js (background.js is not bundled and cannot import these)
+export const CLOSED_TAB_LOG_KEY = 'closedTabLog';
+export const CLOSED_TAB_LOG_CAP = 1000;
+export const LOG_ID_PREFIX = 'log-';
+
+// A session's lastModified has seconds granularity; the window absorbs the rounding
+// when matching our ms-precision log entries against session entries.
+export const DEDUPE_WINDOW_MS = 5000;
+
+export function isLogId(id: string): boolean {
+  return id.startsWith(LOG_ID_PREFIX);
+}
+
+// KEEP IN SYNC with public/background.js
+const NOISE_URL_PREFIXES = ['chrome://', 'chrome-extension://', 'edge://', 'devtools://', 'about:'];
+
+export function isNoiseUrl(url: string): boolean {
+  if (!url) return true;
+  return NOISE_URL_PREFIXES.some(prefix => url.startsWith(prefix));
+}
+
+export function appendToLog(
+  log: ClosedTabLogEntry[],
+  entry: ClosedTabLogEntry,
+  cap: number = CLOSED_TAB_LOG_CAP
+): ClosedTabLogEntry[] {
+  return [entry, ...log].slice(0, cap);
+}
+
+/**
+ * Merge session-backed entries (chrome.sessions API) with our own closed-tab log.
+ *
+ * Log entries that duplicate a session entry (same URL, closed within DEDUPE_WINDOW_MS)
+ * are absorbed by it — one-to-one, so two genuine same-URL closes both survive.
+ * Dedupe runs against the UNFILTERED session list before hiddenIds are applied, so
+ * hiding a session entry doesn't resurrect its log twin.
+ */
+export function mergeClosedTabs(
+  sessionTabs: ClosedTabInfo[],
+  logEntries: ClosedTabLogEntry[],
+  hiddenIds: Set<string>
+): ClosedTabInfo[] {
+  const consumed = new Set<number>(); // indexes of session tabs that absorbed a log entry
+
+  const logTabs: ClosedTabInfo[] = [];
+  for (const entry of logEntries) {
+    if (isNoiseUrl(entry.url)) continue;
+    const twinIndex = sessionTabs.findIndex(
+      (s, i) =>
+        !consumed.has(i) &&
+        s.url === entry.url &&
+        Math.abs(s.closedTime - entry.closedTime) <= DEDUPE_WINDOW_MS
+    );
+    if (twinIndex !== -1) {
+      consumed.add(twinIndex);
+      continue;
+    }
+    logTabs.push({
+      sessionId: entry.id,
+      source: 'log',
+      title: entry.title,
+      url: entry.url,
+      favIconUrl: entry.favIconUrl,
+      closedTime: entry.closedTime,
+    });
+  }
+
+  return [...sessionTabs, ...logTabs]
+    .filter(tab => !hiddenIds.has(tab.sessionId))
+    .sort((a, b) => {
+      if (b.closedTime !== a.closedTime) return b.closedTime - a.closedTime;
+      if (a.source !== b.source) return a.source === 'session' ? -1 : 1;
+      return 0;
+    });
+}
+
+// Storage wrappers
+
+export async function getClosedTabLog(): Promise<ClosedTabLogEntry[]> {
+  const result = await chrome.storage.local.get(CLOSED_TAB_LOG_KEY);
+  return result[CLOSED_TAB_LOG_KEY] ?? [];
+}
+
+export async function removeLogEntries(ids: string[]): Promise<void> {
+  const idSet = new Set(ids);
+  const log = await getClosedTabLog();
+  await chrome.storage.local.set({
+    [CLOSED_TAB_LOG_KEY]: log.filter(entry => !idSet.has(entry.id)),
+  });
+}
+
+export async function clearClosedTabLog(): Promise<void> {
+  await chrome.storage.local.set({ [CLOSED_TAB_LOG_KEY]: [] });
+}
+
+export function subscribeToLogChanges(callback: () => void): () => void {
+  const listener = (
+    changes: { [key: string]: chrome.storage.StorageChange },
+    areaName: string
+  ) => {
+    if (areaName === 'local' && CLOSED_TAB_LOG_KEY in changes) {
+      callback();
+    }
+  };
+  chrome.storage.onChanged.addListener(listener);
+  return () => {
+    chrome.storage.onChanged.removeListener(listener);
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,9 +32,20 @@ export interface DuplicateGroup {
 }
 
 export interface ClosedTabInfo {
+  // Real Chrome sessionId for 'session' entries, synthetic "log-..." id for 'log' entries
   sessionId: string;
+  source: 'session' | 'log';
   title: string;
   url: string;
+  favIconUrl?: string;
+  closedTime: number;
+}
+
+// Entry in the persistent closed-tab log kept in chrome.storage.local by background.js
+export interface ClosedTabLogEntry {
+  id: string;
+  url: string;
+  title: string;
   favIconUrl?: string;
   closedTime: number;
 }


### PR DESCRIPTION
Closes #27

## What

The Recently Closed card was limited by `chrome.sessions.getRecentlyClosed({maxResults: 25})`. This adds our own closed-tab tracking as a **hybrid** layer under the sessions API:

- The background service worker records every tab close into a `chrome.storage.local` log (cap 1000, FIFO). Since `tabs.onRemoved` carries no url/title, a tabId→metadata cache is kept in `chrome.storage.session` (survives MV3 worker restarts), seeded from `tabs.query` on every worker spin-up. All mutations serialize through a promise chain so burst closes (window close) can't race.
- `mergeClosedTabs()` (pure, unit-tested) merges both sources: log entries that duplicate a session entry (same URL, closed within 5s) are absorbed one-to-one; dedupe runs before hidden-ID filtering so hiding a session entry doesn't resurrect its log twin.
- Session-backed entries restore via `sessions.restore()` (full back/forward history); log-only entries reopen via `tabs.create({url})` and are consumed from the log on success. Their row menu drops "Restore to Original Location" and offers **Delete** (real deletion) instead of Hide.
- Card shows 30 entries + a "Show N more (M hidden)" footer (+30 per click, masonry height accounts for it). Search filters the **full** merged list before the display cap.
- **Clear All** is no longer a no-op: clears the log and hides current session entries.
- Noise never logged: `chrome://`, `chrome-extension://`, `about:*`, incognito.
- Manifest: added `storage` permission (no user-facing warning on update).

## Testing

- 13 new Vitest unit tests for the pure merge/dedupe/cap/filter functions (24 total pass).
- E2E via Playwright driving Chromium with the unpacked extension (14 checks, all pass): real tab close lands in the log with a `log-` id; the card shows the close exactly once (dedupe against the sessions API verified); 40 seeded entries → 30 shown + working "Show more"; search finds a beyond-cap entry; clicking a log row opens the tab and consumes the entry; Delete removes from the log; Clear All empties it; `chrome://` closes are never logged.