### PR TITLE
Add toolbar toggle to hide the Recently Closed card

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ Key design decisions and their motivations:
 - 30 tabs shown by default; "Show more" reveals +30 at a time; search filters the full merged list before the display cap
 - Log entries support real deletion; for session entries the sessions API doesn't support deletion, so "Hide" stores session IDs in localStorage (capped at 1000)
 - Noise is never logged: chrome://, chrome-extension://, about:*, incognito tabs
+- The card can be hidden via a toolbar toggle (History icon), persisted to localStorage; hiding empties the closed-tabs list upstream so the card, masonry, search results, and keyboard navigation all skip it — but background logging continues (hiding is a display preference, not a privacy setting)
 - Merge/dedupe logic is pure functions in `src/services/closedTabLog.ts` (unit-tested); constants are duplicated in `public/background.js` because it ships un-bundled
 - Rationale: Extends history beyond the ~25-session API limit while keeping full-fidelity restore where available
 

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -12,6 +12,7 @@ import {
   ArrowsAltOutlined,
   QuestionCircleOutlined,
   GroupOutlined,
+  HistoryOutlined,
 } from '@ant-design/icons';
 import { Button, Dropdown, Tooltip } from 'antd';
 import type { MenuProps } from 'antd';
@@ -39,6 +40,8 @@ interface ToolbarProps {
   allCollapsed: boolean;
   onCollapseAll: () => void;
   onExpandAll: () => void;
+  showRecentlyClosed: boolean;
+  onToggleRecentlyClosed: () => void;
   theme: 'light' | 'dark';
   onToggleTheme: () => void;
 }
@@ -60,6 +63,8 @@ export const Toolbar = forwardRef<ToolbarHandle, ToolbarProps>(function Toolbar(
   allCollapsed,
   onCollapseAll,
   onExpandAll,
+  showRecentlyClosed,
+  onToggleRecentlyClosed,
   theme,
   onToggleTheme,
 }, ref) {
@@ -388,6 +393,25 @@ export const Toolbar = forwardRef<ToolbarHandle, ToolbarProps>(function Toolbar(
             ) : (
               <VerticalAlignMiddleOutlined className="text-lg" />
             )}
+          </button>
+        </Tooltip>
+
+        {/* Show/Hide Recently Closed */}
+        <Tooltip title={showRecentlyClosed ? 'Hide Recently Closed' : 'Show Recently Closed'} placement="bottomRight" mouseEnterDelay={0.3}>
+          <button
+            onClick={onToggleRecentlyClosed}
+            tabIndex={-1}
+            className={`p-2 rounded transition-colors ${
+              showRecentlyClosed
+                ? isDark
+                  ? 'text-mist-300 hover:bg-mist-700 hover:text-white'
+                  : 'text-mist-600 hover:bg-mist-100 hover:text-mist-950'
+                : isDark
+                  ? 'text-mist-600 hover:bg-mist-700 hover:text-mist-400'
+                  : 'text-mist-300 hover:bg-mist-100 hover:text-mist-500'
+            }`}
+          >
+            <HistoryOutlined className="text-lg" />
           </button>
         </Tooltip>
 

--- a/src/manager/App.tsx
+++ b/src/manager/App.tsx
@@ -53,6 +53,13 @@ const CARD_HEADER_HEIGHT = 48;
 const TAB_ITEM_HEIGHT = 32;
 const SHOW_MORE_FOOTER_HEIGHT = 36;
 
+// localStorage key for the Recently Closed card visibility preference
+const SHOW_RECENTLY_CLOSED_KEY = 'tabcluster-show-recently-closed';
+
+function getShowRecentlyClosed(): boolean {
+  return localStorage.getItem(SHOW_RECENTLY_CLOSED_KEY) !== 'false';
+}
+
 // localStorage key for hidden closed tabs
 const HIDDEN_CLOSED_TABS_KEY = 'tabcluster-hidden-closed-tabs';
 // Cap to prevent unbounded growth
@@ -98,6 +105,14 @@ export default function App() {
   const { windows, tabGroups, loading, error } = useWindows();
   const [hiddenClosedTabs, setHiddenClosedTabs] = useState<Set<string>>(getHiddenClosedTabs);
   const { closedTabs, loading: closedLoading } = useRecentlyClosed(hiddenClosedTabs);
+  const [showRecentlyClosed, setShowRecentlyClosed] = useState<boolean>(getShowRecentlyClosed);
+
+  const handleToggleRecentlyClosed = useCallback(() => {
+    setShowRecentlyClosed(prev => {
+      localStorage.setItem(SHOW_RECENTLY_CLOSED_KEY, String(!prev));
+      return !prev;
+    });
+  }, []);
   const { theme, toggleTheme } = useTheme();
   const getWindowNumber = useWindowNumbers(windows);
   const [activeTab, setActiveTab] = useState<TabInfo | null>(null);
@@ -161,6 +176,9 @@ export default function App() {
   const MAX_RECENTLY_CLOSED_TABS_TO_SHOW = 30;
   const [visibleClosedCount, setVisibleClosedCount] = useState(MAX_RECENTLY_CLOSED_TABS_TO_SHOW);
   const searchFilteredClosedTabs = useMemo(() => {
+    // Hiding the card removes closed tabs everywhere downstream: the card itself,
+    // masonry, search results, and keyboard navigation (all key off this list)
+    if (!showRecentlyClosed) return [];
     return searchQuery.trim()
       ? closedTabs.filter(tab => {
           const lowerQuery = searchQuery.toLowerCase();
@@ -168,7 +186,7 @@ export default function App() {
             tab.url.toLowerCase().includes(lowerQuery);
         })
       : closedTabs;
-  }, [closedTabs, searchQuery]);
+  }, [closedTabs, searchQuery, showRecentlyClosed]);
   const filteredClosedTabs = useMemo(
     () => searchFilteredClosedTabs.slice(0, visibleClosedCount),
     [searchFilteredClosedTabs, visibleClosedCount]
@@ -1004,6 +1022,8 @@ export default function App() {
         allCollapsed={allCardsCollapsed}
         onCollapseAll={handleCollapseAll}
         onExpandAll={handleExpandAll}
+        showRecentlyClosed={showRecentlyClosed}
+        onToggleRecentlyClosed={handleToggleRecentlyClosed}
         theme={theme}
         onToggleTheme={toggleTheme}
       />


### PR DESCRIPTION
Closes #29

Addresses user feedback: some users don't use the Recently Closed card and want it out of the way.

## What

- New **History icon** toggle in the toolbar (between Collapse All and Help) that shows/hides the Recently Closed card; the icon dims when the card is hidden, and the tooltip flips between "Hide/Show Recently Closed"
- Preference persists to localStorage (`tabcluster-show-recently-closed`), same pattern as the theme
- Implemented as a single upstream gate: when hidden, the closed-tabs list is emptied before the search/display memos, so the card, masonry layout, **search results**, and **keyboard navigation** all skip it with no per-consumer special-casing
- **Background close-logging continues while hidden** — hiding is a display preference, not a privacy setting; the user's history is intact if they re-enable the card

## Testing

E2E via Playwright with the unpacked extension (7 checks, all pass): card visible by default; toggle hides it; search returns no closed tabs while hidden; Tab-navigation never lands on the hidden card; preference survives page reload; a tab closed while hidden still lands in the log; toggle restores the card with the full list. Also manually verified.