### PR TITLE
Make sort and dedupe group-aware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,12 @@ Key design decisions and their motivations:
 - Focus returns to search input when window gains focus or shortcut is pressed
 - Existing search text is auto-selected so user can type to replace it
 
+### Group-Aware Sort & Dedupe
+- Tab groups are sealed containers: sort keeps each group block in place and sorts tabs within it; ungrouped tabs sort among themselves in the remaining slots; pinned tabs stay put
+- Dedupe only matches duplicates within the same group or among ungrouped tabs (across windows); a URL both inside and outside a group is never deduped
+- Sort executes in two phases: within-group moves first (source and target always inside the block), then ungrouped tabs via extract-then-place — park at window end, then insert into final slots ascending. Chrome ADOPTS a tab moved strictly inside a group's range, and interleaved index moves can transiently shift a block onto an ungrouped slot, so naive slot-by-slot moves corrupt groups. Pure ordering logic is `computeSortedOrder` in `src/services/tabOperations.ts` (unit-tested)
+- Rationale: sorting/deduping must never dismantle the user's tab groups
+
 ### No Confirmation Dialogs
 - Dedupe action executes immediately without confirmation modal
 - Rationale: Faster workflow; user can undo by reopening tabs if needed

--- a/src/services/__tests__/tabOperations.test.ts
+++ b/src/services/__tests__/tabOperations.test.ts
@@ -54,3 +54,120 @@ describe('normalizeUrl', () => {
     expect(normalizeUrl('INVALID')).toBe('invalid');
   });
 });
+
+import { computeSortedOrder, findDuplicates } from '../tabOperations';
+import { TabInfo } from '../../types';
+
+function tab(overrides: Partial<TabInfo> & { id: number; index: number }): TabInfo {
+  return {
+    windowId: 1,
+    title: `Tab ${overrides.id}`,
+    url: `https://example.com/${overrides.id}`,
+    active: false,
+    pinned: false,
+    groupId: -1,
+    ...overrides,
+  };
+}
+
+describe('computeSortedOrder', () => {
+  it('sorts ungrouped tabs as before', () => {
+    const tabs = [
+      tab({ id: 1, index: 0, title: 'Zebra' }),
+      tab({ id: 2, index: 1, title: 'Apple' }),
+      tab({ id: 3, index: 2, title: 'Mango' }),
+    ];
+    const order = computeSortedOrder(tabs, 'title');
+    expect(order.map(t => t.id)).toEqual([2, 3, 1]);
+  });
+
+  it('keeps group blocks in place and sorts within each block', () => {
+    // Layout: [u1, g:a, g:b, u2] — group occupies slots 1-2
+    const tabs = [
+      tab({ id: 1, index: 0, title: 'Zebra' }),
+      tab({ id: 2, index: 1, title: 'Walrus', groupId: 10 }),
+      tab({ id: 3, index: 2, title: 'Bear', groupId: 10 }),
+      tab({ id: 4, index: 3, title: 'Apple' }),
+    ];
+    const order = computeSortedOrder(tabs, 'title');
+    // Group slots 1-2 keep group tabs (sorted: Bear, Walrus);
+    // ungrouped slots 0,3 get sorted ungrouped tabs (Apple, Zebra)
+    expect(order.map(t => t.id)).toEqual([4, 3, 2, 1]);
+    expect(order.map(t => t.groupId)).toEqual([-1, 10, 10, -1]);
+  });
+
+  it('handles multiple groups independently', () => {
+    const tabs = [
+      tab({ id: 1, index: 0, title: 'B', groupId: 10 }),
+      tab({ id: 2, index: 1, title: 'A', groupId: 10 }),
+      tab({ id: 3, index: 2, title: 'Z' }),
+      tab({ id: 4, index: 3, title: 'D', groupId: 20 }),
+      tab({ id: 5, index: 4, title: 'C', groupId: 20 }),
+    ];
+    const order = computeSortedOrder(tabs, 'title');
+    expect(order.map(t => t.id)).toEqual([2, 1, 3, 5, 4]);
+  });
+
+  it('leaves pinned tabs in place', () => {
+    const tabs = [
+      tab({ id: 1, index: 0, title: 'Zebra', pinned: true }),
+      tab({ id: 2, index: 1, title: 'Mango' }),
+      tab({ id: 3, index: 2, title: 'Apple' }),
+    ];
+    const order = computeSortedOrder(tabs, 'title');
+    expect(order.map(t => t.id)).toEqual([1, 3, 2]);
+  });
+
+  it('sorts by domain within groups', () => {
+    const tabs = [
+      tab({ id: 1, index: 0, url: 'https://zzz.com/x', groupId: 10 }),
+      tab({ id: 2, index: 1, url: 'https://aaa.com/y', groupId: 10 }),
+    ];
+    const order = computeSortedOrder(tabs, 'domain');
+    expect(order.map(t => t.id)).toEqual([2, 1]);
+  });
+});
+
+describe('findDuplicates (group-aware)', () => {
+  it('finds duplicates among ungrouped tabs', () => {
+    const tabs = [
+      tab({ id: 1, index: 0, url: 'https://example.com/a' }),
+      tab({ id: 2, index: 1, url: 'https://example.com/a' }),
+    ];
+    const dups = findDuplicates(tabs);
+    expect(dups).toHaveLength(1);
+    expect(dups[0].tabs.map(t => t.id)).toEqual([1, 2]);
+  });
+
+  it('finds duplicates within the same group', () => {
+    const tabs = [
+      tab({ id: 1, index: 0, url: 'https://example.com/a', groupId: 10 }),
+      tab({ id: 2, index: 1, url: 'https://example.com/a', groupId: 10 }),
+    ];
+    expect(findDuplicates(tabs)).toHaveLength(1);
+  });
+
+  it('does not match a grouped tab against an ungrouped duplicate', () => {
+    const tabs = [
+      tab({ id: 1, index: 0, url: 'https://example.com/a', groupId: 10 }),
+      tab({ id: 2, index: 1, url: 'https://example.com/a' }),
+    ];
+    expect(findDuplicates(tabs)).toHaveLength(0);
+  });
+
+  it('does not match duplicates across two different groups', () => {
+    const tabs = [
+      tab({ id: 1, index: 0, url: 'https://example.com/a', groupId: 10 }),
+      tab({ id: 2, index: 1, url: 'https://example.com/a', groupId: 20 }),
+    ];
+    expect(findDuplicates(tabs)).toHaveLength(0);
+  });
+
+  it('still finds ungrouped duplicates across windows', () => {
+    const tabs = [
+      tab({ id: 1, index: 0, url: 'https://example.com/a', windowId: 1 }),
+      tab({ id: 2, index: 0, url: 'https://example.com/a', windowId: 2 }),
+    ];
+    expect(findDuplicates(tabs)).toHaveLength(1);
+  });
+});

--- a/src/services/tabOperations.ts
+++ b/src/services/tabOperations.ts
@@ -36,17 +36,97 @@ export function sortTabs(tabs: TabInfo[], option: SortOption): TabInfo[] {
   return sorted;
 }
 
+/**
+ * Compute the final tab order for a window, treating tab groups as sealed containers:
+ * - Each group block keeps its position in the window; its tabs sort within the block
+ * - Pinned tabs stay in place (Chrome would clamp moves into/out of the pinned region)
+ * - Remaining ungrouped tabs sort among themselves across the remaining slots
+ *
+ * `tabs` must be all tabs of one window; slot i corresponds to window index i.
+ */
+export function computeSortedOrder(tabs: TabInfo[], option: SortOption): TabInfo[] {
+  const byPosition = [...tabs].sort((a, b) => a.index - b.index);
+
+  const groupMembers = new Map<number, TabInfo[]>();
+  const ungrouped: TabInfo[] = [];
+  for (const tab of byPosition) {
+    if (tab.pinned) continue;
+    if (tab.groupId !== -1) {
+      const members = groupMembers.get(tab.groupId) ?? [];
+      members.push(tab);
+      groupMembers.set(tab.groupId, members);
+    } else {
+      ungrouped.push(tab);
+    }
+  }
+  for (const [groupId, members] of groupMembers) {
+    groupMembers.set(groupId, sortTabs(members, option));
+  }
+  const ungroupedSorted = sortTabs(ungrouped, option);
+
+  let ungroupedNext = 0;
+  const groupNext = new Map<number, number>();
+  return byPosition.map(slotTab => {
+    if (slotTab.pinned) return slotTab;
+    if (slotTab.groupId !== -1) {
+      const k = groupNext.get(slotTab.groupId) ?? 0;
+      groupNext.set(slotTab.groupId, k + 1);
+      return groupMembers.get(slotTab.groupId)![k];
+    }
+    return ungroupedSorted[ungroupedNext++];
+  });
+}
+
 export async function applySortToWindow(
   _windowId: number,
   tabs: TabInfo[],
   option: SortOption
 ): Promise<void> {
-  const sorted = sortTabs(tabs, option);
+  const byPosition = [...tabs].sort((a, b) => a.index - b.index);
+  const finalOrder = computeSortedOrder(tabs, option);
 
-  for (let i = 0; i < sorted.length; i++) {
-    const tab = sorted[i];
-    if (tab.index !== i) {
-      await chrome.tabs.move(tab.id, { index: i });
+  // Track positions locally so already-correct tabs are skipped accurately
+  // (chrome.tabs.move removes then re-inserts, which splice mirrors)
+  const current = byPosition.map(t => t.id);
+  const moveTo = async (tabId: number, index: number) => {
+    if (current[index] === tabId) return;
+    await chrome.tabs.move(tabId, { index });
+    current.splice(current.indexOf(tabId), 1);
+    current.splice(index, 0, tabId);
+  };
+
+  // Phase 1: within-group moves only. Both source and target stay inside the
+  // group's block, so Chrome preserves group membership.
+  for (let i = 0; i < finalOrder.length; i++) {
+    if (byPosition[i].groupId !== -1) {
+      await moveTo(finalOrder[i].id, i);
+    }
+  }
+
+  // Phase 2: ungrouped tabs into ungrouped slots, via extract-then-place.
+  // Chrome ADOPTS a tab into a group when it is moved strictly inside the
+  // group's current range, and interleaved index-based moves can transiently
+  // shift a block onto an ungrouped slot. So: first park every out-of-place
+  // ungrouped tab at the window end (always outside any group), then insert
+  // them into their final slots in ascending order — any unsettled block then
+  // sits exactly AT the insertion point, so the insert lands at its head
+  // boundary (outside the group), never in its interior.
+  const ungroupedSlots: number[] = [];
+  for (let i = 0; i < byPosition.length; i++) {
+    if (byPosition[i].groupId === -1 && !byPosition[i].pinned) {
+      ungroupedSlots.push(i);
+    }
+  }
+  const alreadyInPlace = ungroupedSlots.every(i => current[i] === finalOrder[i].id);
+  if (!alreadyInPlace) {
+    for (const i of ungroupedSlots) {
+      const tabId = finalOrder[i].id;
+      await chrome.tabs.move(tabId, { index: -1 });
+      current.splice(current.indexOf(tabId), 1);
+      current.push(tabId);
+    }
+    for (const i of ungroupedSlots) {
+      await moveTo(finalOrder[i].id, i);
     }
   }
 }
@@ -84,17 +164,22 @@ export function normalizeUrl(url: string): string {
 }
 
 export function findDuplicates(tabs: TabInfo[]): DuplicateGroup[] {
-  const urlMap = new Map<string, TabInfo[]>();
+  // Tab groups are sealed containers: duplicates are only detected within the
+  // same group, or among ungrouped tabs (groupId -1 spans windows, matching the
+  // previous cross-window behavior for ungrouped tabs). A URL appearing both
+  // inside and outside a group is never treated as a duplicate.
+  const urlMap = new Map<string, { url: string; tabs: TabInfo[] }>();
 
   for (const tab of tabs) {
     const normalizedUrl = normalizeUrl(tab.url);
-    const existing = urlMap.get(normalizedUrl) || [];
-    existing.push(tab);
-    urlMap.set(normalizedUrl, existing);
+    const key = `${tab.groupId}|${normalizedUrl}`;
+    const existing = urlMap.get(key) || { url: normalizedUrl, tabs: [] };
+    existing.tabs.push(tab);
+    urlMap.set(key, existing);
   }
 
   const duplicates: DuplicateGroup[] = [];
-  for (const [url, tabList] of urlMap) {
+  for (const { url, tabs: tabList } of urlMap.values()) {
     if (tabList.length > 1) {
       duplicates.push({ url, tabs: tabList });
     }


### PR DESCRIPTION
Closes #31

## Problem
Sorting a window moved tabs without regard to tab groups — `chrome.tabs.move()` on a grouped tab ejects it from its group, so sorting silently dismantled the user's groups. Dedupe could similarly pull tabs out of groups.

## Fix: tab groups are sealed containers
**Sort** (`computeSortedOrder`, pure + unit-tested):
- Each group block keeps its exact slots in the window; its tabs sort within the block
- Ungrouped tabs sort among themselves across the remaining slots (one pool flowing around the blocks)
- Pinned tabs stay put (Chrome clamps moves across the pinned boundary anyway)
- Execution is two-phase: within-group moves first (source and target always inside the block, so membership is preserved), then ungrouped tabs via **extract-then-place** — every out-of-place ungrouped tab is parked at the window end (always outside any group), then inserted into its final slot in ascending order. This matters because Chrome *adopts* a tab moved strictly inside a group's range, and naive slot-by-slot moves transiently drift blocks onto ungrouped slots, corrupting groups (found in manual testing on a 4-ungrouped/group/2-ungrouped layout).

**Dedupe** (`findDuplicates`):
- Duplicate matching is keyed by `groupId` + normalized URL: duplicates are detected within the same group, or among ungrouped tabs (which still spans windows, as before)
- A URL appearing both inside and outside a group — or in two different groups — is never deduped

## Testing
- 10 new unit tests (34 total pass): block-in-place sorting, multiple groups, pinned handling, and all dedupe boundary cases
- E2E via Playwright with the unpacked extension:
  - Original suite (7 checks): sort via the card UI keeps the group intact at its slots, sorted within, ungrouped sorted around it; a cross-boundary duplicate survives dedupe-all
  - Regression suite (8 checks) replicating the adoption bug's layout plus a two-group `uuuu111uu22u` pattern: no adoption, no ejection, slot pattern preserved exactly, ungrouped pool globally sorted, sorting twice is stable
- Manually verified