### PR TITLE
Keep tab group intact when moving it to another window

### DIFF
--- a/src/components/WindowCard.tsx
+++ b/src/components/WindowCard.tsx
@@ -21,6 +21,7 @@ import type { InputRef } from 'antd';
 import type { MenuProps } from 'antd';
 import { WindowInfo, SortOption, TabGroupInfo } from '../types';
 import { TabItem, TAB_GROUP_COLORS } from './TabItem';
+import { moveGroupToWindow, moveGroupToNewWindow } from '../services/chromeApi';
 
 const GROUP_COLOR_OPTIONS: chrome.tabGroups.ColorEnum[] = [
   'grey', 'blue', 'red', 'yellow', 'green', 'pink', 'purple', 'cyan', 'orange',
@@ -222,11 +223,7 @@ export function WindowCard({
                   { key: 'move-new-window', icon: <PlusOutlined />, label: 'Move to New Window',
                     onClick: ({ domEvent }) => {
                       domEvent.stopPropagation();
-                      chrome.windows.create({ tabId: groupTabIds[0] }, (newWindow) => {
-                        if (newWindow && groupTabIds.length > 1) {
-                          chrome.tabs.move(groupTabIds.slice(1), { windowId: newWindow.id!, index: -1 });
-                        }
-                      });
+                      moveGroupToNewWindow(selectedGroupMatch.id);
                       setSelectedTabs(new Set());
                     } },
                 ];
@@ -241,7 +238,7 @@ export function WindowCard({
                       </span>,
                       onClick: ({ domEvent }: { domEvent: React.MouseEvent }) => {
                         domEvent.stopPropagation();
-                        chrome.tabs.move(groupTabIds, { windowId: w.id, index: -1 });
+                        moveGroupToWindow(selectedGroupMatch.id, w.id);
                         setSelectedTabs(new Set());
                       },
                     })) as MenuProps['items'],

--- a/src/services/chromeApi.ts
+++ b/src/services/chromeApi.ts
@@ -129,6 +129,49 @@ export function subscribeToChanges(callback: () => void): () => void {
   };
 }
 
+// Tab group API functions
+
+/**
+ * Move an entire tab group to another window, keeping the group intact.
+ * Prefers chrome.tabGroups.move (preserves the group and its identity); falls
+ * back to move-then-regroup (restoring title/color under a new group id) on
+ * Chrome versions that reject cross-window group moves.
+ */
+export async function moveGroupToWindow(groupId: number, targetWindowId: number): Promise<void> {
+  try {
+    await chrome.tabGroups.move(groupId, { windowId: targetWindowId, index: -1 });
+  } catch {
+    const group = await chrome.tabGroups.get(groupId);
+    const tabs = await chrome.tabs.query({ groupId });
+    const tabIds = tabs
+      .sort((a, b) => a.index - b.index)
+      .map(t => t.id)
+      .filter((id): id is number => id !== undefined);
+    if (tabIds.length === 0) return;
+    await chrome.tabs.move(tabIds, { windowId: targetWindowId, index: -1 });
+    const newGroupId = await chrome.tabs.group({
+      tabIds,
+      createProperties: { windowId: targetWindowId },
+    });
+    await chrome.tabGroups.update(newGroupId, { title: group.title, color: group.color });
+  }
+}
+
+/**
+ * Move an entire tab group into a brand-new window, keeping the group intact.
+ * The window is created empty (creating it around a group tab would eject that
+ * tab from the group); its placeholder new-tab is closed after the move.
+ */
+export async function moveGroupToNewWindow(groupId: number): Promise<void> {
+  const newWindow = await chrome.windows.create({});
+  if (!newWindow.id) return;
+  const placeholderTabId = newWindow.tabs?.[0]?.id;
+  await moveGroupToWindow(groupId, newWindow.id);
+  if (placeholderTabId !== undefined) {
+    await chrome.tabs.remove(placeholderTabId);
+  }
+}
+
 // Recently closed tabs API functions
 
 // Hidden-tab filtering happens in mergeClosedTabs (closedTabLog.ts), which needs the


### PR DESCRIPTION
Closes #33

## Problem
Selecting a group and using the group actions menu → **Move to Window** moved all the tabs to the target window but destroyed the group — the tabs arrived ungrouped. **Move to New Window** had the same flaw, plus it created the new window around the group's first tab (`windows.create({tabId})`), which ejects that tab from the group before the move even starts.

## Fix
Two new helpers in `chromeApi.ts`, wired into the group menu in `WindowCard.tsx`:
- `moveGroupToWindow(groupId, windowId)` — uses `chrome.tabGroups.move()`, which relocates the entire group with membership, title, color, **and group identity** intact. Fallback for Chrome versions that reject cross-window group moves: move tabs in order, re-group, restore title/color (new group id in that path only).
- `moveGroupToNewWindow(groupId)` — creates an **empty** window, moves the group in via the helper above, then closes the placeholder new-tab.

## Testing
E2E via Playwright with the unpacked extension, driven through the real UI (color-strip click to select the group → group menu). 9 checks, all pass:
- Move to existing window: group arrives with both tabs, title, and color intact — same group id (native `tabGroups.move` path, no fallback needed)
- Move to new window: new window created, group intact inside it, placeholder tab closed (window contains only the group's tabs)

Manually verified.