### PR TITLE
Preserve tab groups when merging windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ Key design decisions and their motivations:
 - Select 2+ windows via checkboxes, then click "Merge Selected"
 - If current window (containing Tab Cluster) is selected, it becomes the target
 - After merge, Tab Cluster stays focused (doesn't switch to merged window)
+- Tab groups survive merging: ungrouped tabs move via tabs.move, groups via moveGroupToWindow (cross-window tabs.move would strip membership)
 - Rationale: Keeps Tab Cluster visible and accessible during workflow
 
 ### Masonry Layout

--- a/src/services/tabOperations.ts
+++ b/src/services/tabOperations.ts
@@ -1,5 +1,5 @@
 import { TabInfo, WindowInfo, SortOption, DuplicateGroup } from '../types';
-import { moveTabs, closeTabs } from './chromeApi';
+import { moveTabs, closeTabs, moveGroupToWindow } from './chromeApi';
 
 export async function mergeWindows(
   sourceWindowIds: number[],
@@ -7,10 +7,19 @@ export async function mergeWindows(
   windows: WindowInfo[]
 ): Promise<void> {
   const sourceWindows = windows.filter(w => sourceWindowIds.includes(w.id));
-  const tabIds = sourceWindows.flatMap(w => w.tabs.map(t => t.id));
 
-  if (tabIds.length > 0) {
-    await moveTabs(tabIds, targetWindowId, -1);
+  for (const window of sourceWindows) {
+    // Cross-window tabs.move strips group membership, so groups must travel
+    // via moveGroupToWindow (tabGroups.move keeps membership/title/color)
+    const ungroupedTabIds = window.tabs.filter(t => t.groupId === -1).map(t => t.id);
+    const groupIds = [...new Set(window.tabs.map(t => t.groupId).filter(id => id !== -1))];
+
+    if (ungroupedTabIds.length > 0) {
+      await moveTabs(ungroupedTabIds, targetWindowId, -1);
+    }
+    for (const groupId of groupIds) {
+      await moveGroupToWindow(groupId, targetWindowId);
+    }
   }
 }
 


### PR DESCRIPTION
Closes #35

## Problem
Merge Windows moved every tab of the source windows with a raw `chrome.tabs.move()`, which strips group membership on cross-window moves. The target window's groups survived (its tabs never move), but every source-window group arrived as loose ungrouped tabs — grouping, title, and color lost.

## Fix
`mergeWindows` now partitions each source window's tabs:
- Ungrouped tabs move via `tabs.move` as before
- Each tab group travels via `moveGroupToWindow()` (the `chrome.tabGroups.move` helper from #34), arriving with membership, title, color, and group identity intact

## Testing
- 34 unit tests pass; build clean
- E2E via Playwright with the unpacked extension, driving the real toolbar merge popover (8 checks, all pass): three windows — target with group TG(blue) + ungrouped tabs, sources with BG(red):[Walrus, Bear] and CG(green):[Quill] + ungrouped tabs — merged into one window with **all three groups intact** (titles, colors, members), all 10 tabs present, all groups in the target window.